### PR TITLE
Fix the import error about fcrypt on WIndows

### DIFF
--- a/password_cracker.py
+++ b/password_cracker.py
@@ -8,7 +8,22 @@
 
 # Description	: Old school password cracker using python
 
-import crypt	# Import the module
+from sys import platform as _platform
+
+# Check the current operating system to import the correct version of crypt
+if _platform == "linux" or _platform == "linux2":
+    import crypt # Import the module
+elif _platform == "darwin":
+    # Mac OS X
+    import crypt
+elif _platform == "win32":
+    # Windows
+    try:
+       import fcrypt # Try importing the fcrypt module
+    except ImportError:
+       print 'Please install fcrypt if you are on Windows'
+
+
 
 def testPass(cryptPass):	# Start the function
   salt = cryptPass[0:2]


### PR DESCRIPTION
Fixed the import error when using Windows because of crypt module not existing there. <b>Regarding the issue recently of the 'no file found dictionary.txt' or 'no file found dictionary.txt'</b> You need to create both the file and put it into the same directory because the project's zip file does not include them. Any questions or problem, please comment.

Closes #8