### PR TITLE
Keep image extension for xkcd comics

### DIFF
--- a/xkcd_downloader.py
+++ b/xkcd_downloader.py
@@ -31,7 +31,6 @@ def main():
     
     # gets comic name from the image src url
     comic_name = image_src.split('/')[-1]
-    comic_name = comic_name[:-4]
     
     # save location of comic
     comic_location = os.getcwd() + '/comics/'


### PR DESCRIPTION
It might be best to just keep the file extension, to prevent confusion. Especially on Windows where how the file is opened depends on the file extension. 