### PR TITLE
Removed system argument and removed the first row multiplication table

### DIFF
--- a/multiplication_table.py
+++ b/multiplication_table.py
@@ -1,14 +1,9 @@
-from sys import argv # import argment variable 
+argv = input('Number of ROWS and COLUMBS: ')
 
-script, rows, columns = argv # define rows and columns for the table and assign them to the argument variable
+script, rows, columns = argv, argv, argv # define rows and columns for the table and assign them to the argument variable
 
 
 def table(rows, columns):
-	for i in range(1, int(rows) + 1 ): # it's safe to assume that the user would mean 12 rows when they provide 12 as an argument, b'coz 12 will produce 11 rows
-		print ("\t", i,)
-
-	print ("\n\n") # add 3 lines
-
 	for i in range(1, int(columns) + 1 ):
 		print (i),
 		for j in range(1, int(rows) + 1 ):


### PR DESCRIPTION
Fixed the code of the multiplication table so it works without the system argument using an input, and removed the first row when it prints, so it's only 1 row - argv rows.