### PR TITLE
performance optimization of primelib.isPrime(number)

### DIFF
--- a/primelib/primelib.py
+++ b/primelib/primelib.py
@@ -73,15 +73,15 @@ def isPrime(number):
     
     # 0 and 1 are none primes. 
     if number <= 1:
-        status = False
-    
-    for divisor in range(2,int(round(math.sqrt(number)))+1):
+        return False
         
-        # if 'number' divisible by 'divisor' then sets 'status'
-        # of false and break up the loop. 
-        if number % divisor == 0:
-            status = False
-            break
+    # all even numbers except of 2 are no primes.    
+    if number % 2 == 0 and number > 2:
+        return False
+        
+    # if 'number' divisible by 'divisor' then sets 'status' to false.
+    # lazy evaluation breaks the all loop on first false.
+    status = all(number % divisor for divisor in range(3, int(math.sqrt(number)) + 1, 2))
     
     # precondition
     assert isinstance(status,bool), "'status' must been from type bool"    


### PR DESCRIPTION
only loop over the odd numbers.


## performance test:

### old version:

In [1]: from primelib import isPrime

In [2]: %timeit isPrime(99999999999999997)
50.9 s ± 31.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


### new version:

In [1]: from primelib import isPrime

In [2]: %timeit isPrime(99999999999999997)
32.4 s ± 149 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)