### PR TITLE
Remove syntax errors from assembler.py

### DIFF
--- a/Assembler/assembler.py
+++ b/Assembler/assembler.py
@@ -1,6 +1,4 @@
 import sys
-//WE NEED TSHIRT FOR HACKTOBER FEST.
-//PLEASE ACCEPT MY PR.
 
 lines = [] # contains the lines of the file. 
 tokens = [] # contains all tokens of the source code.


### PR DESCRIPTION
// does not form a valid comment in Python, # does.