### PR TITLE
Fix IndentationError: unexpected indent

### DIFF
--- a/Google_News.py
+++ b/Google_News.py
@@ -11,19 +11,19 @@ def news(xml_news_url):
       '''
 
     context = ssl._create_unverified_context()
-        Client=urlopen(xml_news_url, context=context)
-        xml_page=Client.read()
-        Client.close()
+    Client=urlopen(xml_news_url, context=context)
+    xml_page=Client.read()
+    Client.close()
 
-        soup_page=soup(xml_page,"xml")
+    soup_page=soup(xml_page,"xml")
 
-        news_list=soup_page.findAll("item")
+    news_list=soup_page.findAll("item")
 
-        for news in news_list:
-            print(f'news title:   {news.title.text}')
-            print(f'news link:    {news.link.text}')
-            print(f'news pubDate: {news.pubDate.text}')
-            print("+-"*20,"\n\n")
+    for news in news_list:
+        print(f'news title:   {news.title.text}')
+        print(f'news link:    {news.link.text}')
+        print(f'news pubDate: {news.pubDate.text}')
+        print("+-"*20,"\n\n")
 
 #you can add google news 'xml' URL here for any country/category
 news_url="https://news.google.com/news/rss/?ned=us&gl=US&hl=en"


### PR DESCRIPTION
Sorry.  This was an oversight in #449

[flake8](http://flake8.pycqa.org) testing of https://github.com/geekcomputers/Python on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./TicTacToe.py:10:10: F821 undefined name 'raw_input'
		return raw_input()
         ^
./Google_News.py:14:8: E999 IndentationError: unexpected indent
        Client=urlopen(xml_news_url, context=context)
       ^
./spotlight.py:63:12: F821 undefined name 'raw_input'
    PATH = raw_input("Enter directory path:")
           ^
./dir_test.py:18:22: F821 undefined name 'raw_input'
        input_func = raw_input
                     ^
./GroupSms_Way2.py:11:3: F821 undefined name 'raw_input'
x=raw_input('Enter Mobile numbers seperated with comma:')
  ^
./dice_rolling_simulator.py:20:5: F821 undefined name 'raw_input'
    raw_input(">")
    ^
./dice_rolling_simulator.py:38:25: F821 undefined name 'raw_input'
    user_dice_chooser = raw_input(">")
                        ^
./dice_rolling_simulator.py:87:29: F821 undefined name 'raw_input'
    user_exit_checker_raw = raw_input("\r\nIf you want to roll another die, type [roll]. To exit, type [exit].\r\n?>")
                            ^
./nDigitNumberCombinations.py:4:14: F821 undefined name 'n'
		npow = 10**n
             ^
./nDigitNumberCombinations.py:7:25: F821 undefined name 'n'
			code=str(code).zfill(n)
                        ^
./ftp_send_receive.py:12:80: E999 SyntaxError: invalid syntax
ftp = FTP('xxx.xxx.x.x')    """ Enter the ip address or the domain name here """   
                                                                               ^
./sendemail.py:42:20: F821 undefined name 'createMessageWithAttachment'
        message1 = createMessageWithAttachment(sender, to, subject, msgHtml, msgPlain, attachmentFile)
                   ^
./tweeter.py:15:16: F821 undefined name 'raw_input'
        line = raw_input()
               ^
./tweeter.py:34:25: F821 undefined name 'raw_input'
		pic = os.path.abspath(raw_input())
                        ^
./tweeter.py:59:13: F821 undefined name 'raw_input'
	doit = int(raw_input("\n1. text\n2. picture\n"))
            ^
./pscheck.py:17:13: F821 undefined name 'raw_input'
  program = raw_input("Enter the name of the program to check: ")
            ^
./EncryptionTool.py:16:17: F821 undefined name 'raw_input'
    input_fun = raw_input
                ^
./CountMillionCharacters-Variations/variation1.py:4:18: F821 undefined name 'raw_input'
    input_func = raw_input
                 ^
./Assembler/assembler.py:930:25: E999 SyntaxError: invalid syntax
            print "line=",line
                        ^
3     E999 SyntaxError: invalid syntax
16    F821 undefined name 'raw_input'
19
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree