### PR TITLE
Fix undefined name 'n' in nDigitNumberCombinations.py

### DIFF
--- a/nDigitNumberCombinations.py
+++ b/nDigitNumberCombinations.py
@@ -10,3 +10,8 @@ def nDigitCombinations(n):
 		# handle all other exceptions
 		pass    
 	return(numbers)
+
+# An alternate solution:
+# from itertools import product
+# from string import digits
+# list("".join(x) for x in product(digits, repeat=n))

--- a/nDigitNumberCombinations.py
+++ b/nDigitNumberCombinations.py
@@ -1,5 +1,5 @@
 # ALL the combinations of n digit combo
-def nDigitCombinations():
+def nDigitCombinations(n):
 	try:
 		npow = 10**n
 		numbers=[]


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/geekcomputers/Python on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./nDigitNumberCombinations.py:4:14: F821 undefined name 'n'
		npow = 10**n
             ^
./nDigitNumberCombinations.py:7:25: F821 undefined name 'n'
			code=str(code).zfill(n)
                        ^
2    F821 undefined name 'n'
2
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree