### PR TITLE
Properly import URLError and urlopen in both Python 2 and Python 3

### DIFF
--- a/check_internet_con.py
+++ b/check_internet_con.py
@@ -2,8 +2,8 @@
 
 try:
     # For Python 3.0 and later
-    from urllib.request import urlopen
     from urllib.error import URLError
+    from urllib.request import urlopen
 except ImportError:
     # Fall back to Python 2's urllib2
     from urllib2 import URLError, urlopen

--- a/check_internet_con.py
+++ b/check_internet_con.py
@@ -12,7 +12,7 @@ def checkInternetConnectivity():
     try:
         urlopen("http://google.com", timeout=2)
         print("Working connection")
-    except urllib2.URLError as E:
+    except URLError as E:
         print("Connection error:%s" % E.reason)
 
 

--- a/check_internet_con.py
+++ b/check_internet_con.py
@@ -3,15 +3,15 @@
 try:
     # For Python 3.0 and later
     from urllib.request import urlopen
+    from urllib.error import URLError
 except ImportError:
     # Fall back to Python 2's urllib2
-    from urllib2 import urlopen
+    from urllib2 import URLError, urlopen
 
 def checkInternetConnectivity():
     try:
-        urllib2.urlopen("http://google.com", timeout=2)
+        urlopen("http://google.com", timeout=2)
         print("Working connection")
-
     except urllib2.URLError as E:
         print("Connection error:%s" % E.reason)
 


### PR DESCRIPTION
flake8 testing of https://github.com/geekcomputers/Python on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./check_internet_con.py:12:9: F821 undefined name 'urllib2'
        urllib2.urlopen("http://google.com", timeout=2)
        ^
./check_internet_con.py:15:12: F821 undefined name 'urllib2'
    except urllib2.URLError as E:
           ^
```