### PR TITLE
[GH-494]  Url change in weather scrapper

### DIFF
--- a/Weather Scrapper/weather.py
+++ b/Weather Scrapper/weather.py
@@ -4,7 +4,9 @@ from datetime import datetime
 import csv
 
 city = input('Enter City')
-url = 'https://www.wunderground.com/weather/in/' + city
+national_code = input('Enter National Code')
+
+url = f'https://www.wunderground.com/weather/{national_code}/{city}'
 
 try:
 	response = requests.get(url)


### PR DESCRIPTION
Summary :
The url of query of city has already changed, and there's national code between city name and 'https://www.wunderground.com/weather/'
for example:
the 'https://www.wunderground.com/weather/in/taizhou' doesn't work while 'https://www.wunderground.com/weather/cn/taizhou' works