### PR TITLE
Enforce an interactive backend

### DIFF
--- a/game_of_life/game_o_life.py
+++ b/game_of_life/game_o_life.py
@@ -31,6 +31,9 @@ import random
 import sys
 
 import numpy as np
+
+from matplotlib import use as mpluse
+mpluse('TkAgg')
 from matplotlib import pyplot as plt
 from matplotlib.colors import ListedColormap
 


### PR DESCRIPTION
The script currently runs with the default matplotlib backend. However, it needs an interactive backend.

On my machine, the default happened to be AGG which is not an interactive backend and resulted in the following error.

`game_o_life.py:117: UserWarning: Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.
  fig.show()`

It now relies on TkAGG which use tk that should be included by default.