### PR TITLE
Add custom url support

### DIFF
--- a/check_internet_con.py
+++ b/check_internet_con.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python3
-
+from sys import argv
 try:
     # For Python 3.0 and later
     from urllib.error import URLError
@@ -11,8 +10,15 @@ except ImportError:
 
 def checkInternetConnectivity():
     try:
-        urlopen("http://google.com", timeout=2)
-        print("Working connection")
+        url = argv[1]
+        if 'https://' or 'http://' not in url:
+            url = 'https://' + url
+    except:
+        url = 'https://google.com'
+    try:
+         urlopen(url, timeout=2)
+         print("Connection to \""+ url + "\" is working")
+        
     except URLError as E:
         print("Connection error:%s" % E.reason)
 


### PR DESCRIPTION
Added a second optional parameter to "python3 check_internet_con.py" to attempt to connect to a custom url. If no url is given, it defaults to https://google.com. If you forget to add "https://" or "http://" it adds it for you.