### PR TITLE
Use eval() replace globals() & fix spell mistake

### DIFF
--- a/Google_Image_Downloader/image_grapper.py
+++ b/Google_Image_Downloader/image_grapper.py
@@ -158,8 +158,9 @@ while run:
     ''')
     choice = input()
     try:
-        fx = FX[int(choice)]
-        run = globals()[fx]()
+        # Via eval() let `str expression` to `function`
+        fx = eval(FX[int(choice)])
+        run = fx()
     except KeyError:
         system('clear')
         if count <= 5:
@@ -167,5 +168,5 @@ while run:
             print("----------enter proper key-------------")
         else:
             system('clear')
-            print("You have attemted 5 times , try again later")
+            print("You have attempted 5 times , try again later")
             run = False


### PR DESCRIPTION
`globals()` would return all the current scope variable dict, it will make the code a bit chaos. Lucky, the `FX` dict value is also the calling function name itself. So the `eval()` could be a little helper to handle this dirty work property.