### PR TITLE
Basic 'cat' program v1

### DIFF
--- a/Cat/cat.py
+++ b/Cat/cat.py
@@ -1,0 +1,63 @@
+"""
+The 'cat' Program Implemented in Python 3
+
+The Unix 'cat' utility reads the contents
+of file(s) and 'conCATenates' into stdout.
+If it is run without any filename(s) given,
+then the program reads from standard input,
+which means it simply copies stdin to stdout.
+
+It is fairly easy to implement such a program
+in Python, and as a result countless examples
+exist online. This particular implementation
+focuses on the basic functionality of the cat
+utility. Compatible with Python 3.6 or higher.
+
+Syntax:
+python3 cat.py [filename1,filename2,etcetera]
+Separate filenames with commas and not spaces!
+
+David Costell (DontEatThemCookies on GitHub)
+v1 - 02/06/2022
+"""
+import sys
+
+def with_files(files):
+    """Executes when file(s) is/are specified."""
+    file_contents = []
+    try:
+        # Read the files' contents and store their contents
+        for file in files:
+            with open(file) as f:
+                file_contents.append(f.read())
+    except OSError as err:
+        # This executes when there's an error (e.g. FileNotFoundError)
+        print(f"cat: error reading files ({err})")
+
+    # Write the contents of all files into the standard output stream
+    for contents in file_contents:
+        sys.stdout.write(contents)
+
+def no_files():
+    """Executes when no file(s) is/are specified."""
+    try:
+        # Loop getting input then outputting the input.
+        while True:
+            inp = input()
+            print(inp)
+    # Gracefully handle Ctrl + C and Ctrl + D
+    except KeyboardInterrupt:
+        exit()
+    except EOFError:
+        exit()
+
+def main():
+    """Entry point of the cat program."""
+    try:
+        # Read the arguments passed to the program
+        with_files(sys.argv[1].strip().split(","))
+    except IndexError:
+        no_files()
+
+if __name__ == "__main__":
+    main()

--- a/Cat/text_a.txt
+++ b/Cat/text_a.txt
@@ -1,0 +1,7 @@
+Sample Text Here
+
+Lorem ipsum, dolor sit amet.
+Hello,
+World!
+
+ABCD 1234

--- a/Cat/text_b.txt
+++ b/Cat/text_b.txt
@@ -1,0 +1,7 @@
+I am another sample text file.
+
+The knights who say ni!
+
+Lines
+of
+Text!


### PR DESCRIPTION
A basic implementation of the Unix 'cat' program

Syntax:
```
python3 cat.py [filename1,filename2,etc.]
```
Example:
```
python3 cat.py textfile1.txt,textfile2.txt
```
Do not put spaces as separators, only commas
You can leave the arguments empty to read from stdin instead
