### PR TITLE
Cat program revised (v2)

### DIFF
--- a/Cat/cat.py
+++ b/Cat/cat.py
@@ -49,11 +49,11 @@ def no_files():
 
 def main():
     """Entry point of the cat program."""
-    try:
-        # Read the arguments passed to the program
-        with_files(sys.argv[1:])
-    except IndexError:
+    # Read the arguments passed to the program
+    if not sys.argv[1:]:
         no_files()
+    else:
+        with_files(sys.argv[1:])
 
 if __name__ == "__main__":
     main()

--- a/Cat/cat.py
+++ b/Cat/cat.py
@@ -2,9 +2,9 @@
 The 'cat' Program Implemented in Python 3
 
 The Unix 'cat' utility reads the contents
-of file(s) and 'conCATenates' into stdout.
-If it is run without any filename(s) given,
-then the program reads from standard input,
+of file(s) specified through stdin and 'conCATenates'
+into stdout. If it is run without any filename(s) given,
+then the program reads from standard input itself,
 which means it simply copies stdin to stdout.
 
 It is fairly easy to implement such a program
@@ -14,55 +14,46 @@ focuses on the basic functionality of the cat
 utility. Compatible with Python 3.6 or higher.
 
 Syntax:
-python3 cat.py [filename1 filename2 etcetera]
-Separate filenames with spaces as usual.
+python3 cat.py [filename1] [filename2] etc...
+Separate filenames with spaces.
 
 David Costell (DontEatThemCookies on GitHub)
-v1 - 02/06/2022
+v2 - 03/12/2022
 """
 import sys
 
-
 def with_files(files):
     """Executes when file(s) is/are specified."""
-    file_contents = []
     try:
-        # Read the files' contents and store their contents
-        for file in files:
-            with open(file) as f:
-                file_contents.append(f.read())
+        # Read each file's contents and store them
+        file_contents = [contents for contents in [open(file).read() for file in files]]
     except OSError as err:
         # This executes when there's an error (e.g. FileNotFoundError)
-        print(f"cat: error reading files ({err})")
+        exit(print(f"cat: error reading files ({err})"))
 
-    # Write the contents of all files into the standard output stream
+    # Write all file contents into the standard output stream
     for contents in file_contents:
         sys.stdout.write(contents)
-
 
 def no_files():
     """Executes when no file(s) is/are specified."""
     try:
-        # Loop getting input then outputting the input.
+        # Get input, output the input, repeat
         while True:
-            inp = input()
-            print(inp)
-    # Gracefully handle Ctrl + C and Ctrl + D
+            print(input())
+    # Graceful exit for Ctrl + C, Ctrl + D
     except KeyboardInterrupt:
         exit()
     except EOFError:
         exit()
 
-
 def main():
     """Entry point of the cat program."""
     try:
         # Read the arguments passed to the program
-        file = sys.argv[1:]
-        with_files(file)
+        with_files(sys.argv[1:])
     except IndexError:
         no_files()
-
 
 if __name__ == "__main__":
     main()

--- a/Cat/text_b.txt
+++ b/Cat/text_b.txt
@@ -5,3 +5,4 @@ The knights who say ni!
 Lines
 of
 Text!
+This file does not end with a newline.

--- a/Cat/text_c.txt
+++ b/Cat/text_c.txt
@@ -1,0 +1,3 @@
+I am the beginning of yet another text file.
+
+Spam and eggs.


### PR DESCRIPTION
Changes:
* File argument syntax changed to imitate the real cat program: `python3 cat.py [filename1] [filename2] etc.` (thanks to @BBarbuz)
* Some comments modified
* Other miscellaneous changes
***
A basic implementation of the Unix 'cat' program

Syntax:
```
python3 cat.py [filename1,filename2,etc.]
```
Example:
```
python3 cat.py textfile1.txt textfile2.txt etc.
```
Just like the real cat program, separate filenames with spaces.
You can leave the arguments empty to read from stdin instead
