### PR TITLE
Cat program v3

### DIFF
--- a/Cat/cat.py
+++ b/Cat/cat.py
@@ -14,29 +14,41 @@ focuses on the basic functionality of the cat
 utility. Compatible with Python 3.6 or higher.
 
 Syntax:
-python3 cat.py [filename1] [filename2] etc...
+python3 cat.py [filenames...]
+Any number of arguments can be specified.
 Separate filenames with spaces.
 
 David Costell (DontEatThemCookies on GitHub)
-v2 - 03/12/2022
+v3 - 05/06/2022
 """
 import sys
+import argparse
 
-def with_files(files):
-    """Executes when file(s) is/are specified."""
+
+def with_files(files: list) -> None:
+    """
+    Executes when arguments are specified.
+    The argument list is passed into this
+    function to be worked on.
+    """
     try:
-        # Read each file's contents and store them
+        # Read each file's contents and store them (list comprehension is used here)
         file_contents = [contents for contents in [open(file).read() for file in files]]
     except OSError as err:
-        # This executes when there's an error (e.g. FileNotFoundError)
-        exit(print(f"cat: error reading files ({err})"))
+        # This executes when an exception is raised (e.g. FileNotFoundError)
+        print(f"cat has encountered an error!\n{err}")
+        exit(1)
+    else:
+        # Write all file contents into the standard output stream
+        for contents in file_contents:
+            sys.stdout.write(contents)
 
-    # Write all file contents into the standard output stream
-    for contents in file_contents:
-        sys.stdout.write(contents)
 
-def no_files():
-    """Executes when no file(s) is/are specified."""
+def no_files() -> None:
+    """
+    Executes when no arguments are specified.
+    Copies standard input to standard output.
+    """
     try:
         # Get input, output the input, repeat
         while True:
@@ -47,13 +59,23 @@ def no_files():
     except EOFError:
         exit()
 
+
 def main():
-    """Entry point of the cat program."""
+    """Entry point of the program."""
     # Read the arguments passed to the program
-    if not sys.argv[1:]:
+    parser = argparse.ArgumentParser(
+        prog="cat",
+        description="Simple recreation of the Unix cat utility in Python",
+        epilog="version 3 - by DontEatThemCookies"
+    )
+    parser.add_argument("filenames", nargs="*")
+    filenames = parser.parse_args().filenames
+
+    if not filenames:
         no_files()
     else:
-        with_files(sys.argv[1:])
+        with_files(filenames)
+
 
 if __name__ == "__main__":
     main()

--- a/Cat/text_a.txt
+++ b/Cat/text_a.txt
@@ -4,4 +4,6 @@ Lorem ipsum, dolor sit amet.
 Hello,
 World!
 
+!@#$
+
 ABCD 1234

--- a/Cat/text_b.txt
+++ b/Cat/text_b.txt
@@ -1,6 +1,7 @@
 I am another sample text file.
 
 The knights who say ni!
+Bacon
 
 Lines
 of

--- a/Cat/text_c.txt
+++ b/Cat/text_c.txt
@@ -1,3 +1,5 @@
 I am the beginning of yet another text file.
 
+Allan please add details
+
 Spam and eggs.


### PR DESCRIPTION
The third revision to the basic recreation of the Unix cat utility in Python.

Changes:
- Now using `argparse` instead of `sys.argv` to read program arguments.
- Code has been made PEP 8 compliant.
- Docstring changes
***
A basic implementation of the Unix 'cat' program.

Syntax:
```
python3 cat.py [filename1] [filename2] etc...
```
Example:
```
python3 cat.py textfile1.txt textfile2.txt etc.
```
Just like the real cat program, separate filenames with spaces.
You can read from stdin instead by supplying no arguments.
