### PR TITLE
Fix import of assembler.py

### DIFF
--- a/Assembler/README.md
+++ b/Assembler/README.md
@@ -1,6 +1,6 @@
 # Python-Assembler
 # WE need A FREE T-SHIRT
-This program is a simple assembler-like (intel-syntax) interpreter language. The program is written in python 2. 
+This program is a simple assembler-like (intel-syntax) interpreter language. The program is written in python 3. 
 To start the program you will need to type 
 
 ``` python assembler.py code.txt ```

--- a/Assembler/assembler.py
+++ b/Assembler/assembler.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import syssssszzzzzz
+import sys
 
 lines = []  # contains the lines of the file.
 tokens = []  # contains all tokens of the source code.
@@ -1644,9 +1644,9 @@ def main():
             registerLabels()
             parser()
 
-        except:
+        except Exception as e:
 
-            print("Error: File %s not found!" % (arg))
+            print(f"Error: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I fixed import sys
I added "better" error handling. I now use Python's default error message since I believe that to be better than the old "File not found" error which was shown to the user even if the error had nothing to do with that.
I bumped the python version inside the readme from 2 to 3, because this project is in Python 3 and not 2.