### PR TITLE
Added offline text to speech

### DIFF
--- a/SpeechToText.py
+++ b/SpeechToText.py
@@ -1,0 +1,14 @@
+import pyttsx3
+
+engine = pyttsx3.init()
+
+voices = engine.getProperty("voices")
+for voice in voices:
+    print(voice.id)
+    print(voice.name)
+
+id ="HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\TTS_MS_EN-US_DAVID_11.0"
+engine.setProperty("voices",id )
+engine.setProperty("rate",165)
+engine.say("jarivs")  # Replace string with our own text
+engine.runAndWait()


### PR DESCRIPTION
This PR adds a simple Python script to convert text to speech using the `pyttsx3` library. It addresses issue #2511.

The script allows users to enter text and hear it spoken aloud using an offline voice engine. Unlike online TTS tools, this works without internet, making it lightweight and easy to use.

Let me know if any changes are needed.
