### PR TITLE
 Removed redundant header line from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-#This is a new repo
 # My Python Eggs 🐍 😄
 
 <hr>


### PR DESCRIPTION
Removed the line `#This is a new repo` from the README file, as it appeared to be an initial placeholder and did not add value to the documentation. This change helps keep the README clean and focused on the project details.

---

![Screenshot from 2025-04-22 08-54-08](https://github.com/user-attachments/assets/c0934929-b177-4f0c-b7c8-2b90d08d81d7)
