### PR TITLE
Added a simple python script to display system information

### DIFF
--- a/Pc_information.py
+++ b/Pc_information.py
@@ -1,0 +1,11 @@
+import platform # built in lib 
+
+print(f"System : {platform.system()}")  # Prints type of Operating System 
+print(f"System name : {platform.node()}") # Prints System Name
+print(f"version : {platform.release()}") # Prints System Version
+# TO get the detailed version number 
+print(f"detailed version number : {platform.version()}") # Prints detailed version number 
+print(f"System architecture : {platform.machine()}") # Prints whether the system is 32-bit ot 64-bit 
+print(f"System processor : {platform.processor()}") # Prints CPU model
+
+


### PR DESCRIPTION
This PR contains a Python program that uses the platform module to display information about computer's system and hardware. It shows details like your operating system, computer name, version, system architecture (32-bit or 64-bit), and processor type.

Addresses issue: #1117