### PR TITLE
Bump numpy from 2.4.0 to 2.4.1

### DIFF
--- a/Hand-Motion-Detection/requirements.txt
+++ b/Hand-Motion-Detection/requirements.txt
@@ -1,3 +1,3 @@
-numpy==2.4.0
+numpy==2.4.1
 opencv_python==4.12.0.88
 mediapipe==0.10.31

--- a/requirements_with_versions.txt
+++ b/requirements_with_versions.txt
@@ -15,7 +15,7 @@ dictator==0.3.1
 caller==0.0.2
 watchdog==6.0.0
 PyQt5==5.15.11
-numpy==2.4.0
+numpy==2.4.1
 fileinfo==0.3.3
 backend==0.2.4.1
 win10toast==0.9


### PR DESCRIPTION
Closes #3131 

Updated NumPy version from 2.4.0 to 2.4.1 as requested in the issue